### PR TITLE
Removes differentiation

### DIFF
--- a/app/media_sources/facebook_media_source.rb
+++ b/app/media_sources/facebook_media_source.rb
@@ -3,6 +3,13 @@ class FacebookMediaSource < MediaSource
   include Forki
   attr_reader(:url)
 
+  # A string to indicate what type of scraper this model is for
+  #
+  # @return [String] the canonical name for the type this scraper handles
+  def self.model_type
+    "facebook"
+  end
+
   # Limit all urls to the host below
   #
   # @return [String] or [Array] of [String] of valid host names
@@ -55,6 +62,12 @@ class FacebookMediaSource < MediaSource
   def retrieve_facebook_post
     # Unlike Zorki, Forki expects a full URL
     Forki::Post.lookup(url)
+  end
+
+  def self.can_handle_url?(url)
+    FacebookMediaSource.send(:validate_facebook_post_url, url)
+  rescue FacebookMediaSource::InvalidFacebookPostUrlError
+    false
   end
 end
 

--- a/app/media_sources/instagram_media_source.rb
+++ b/app/media_sources/instagram_media_source.rb
@@ -1,6 +1,13 @@
 class InstagramMediaSource < MediaSource
   attr_reader(:url)
 
+  # A string to indicate what type of scraper this model is for
+  #
+  # @return [String] the canonical name for the type this scraper handles
+  def self.model_type
+    "instagram"
+  end
+
   # Limit all urls to the host below
   #
   # @return [String] or [Array] of [String] of valid host names
@@ -45,6 +52,12 @@ class InstagramMediaSource < MediaSource
   def retrieve_instagram_post
     id = InstagramMediaSource.extract_instagram_id_from_url(@url)
     Zorki::Post.lookup(id)
+  end
+
+  def self.can_handle_url?(url)
+    InstagramMediaSource.send(:validate_instagram_post_url, url)
+  rescue InstagramMediaSource::InvalidInstagramPostUrlError
+    false
   end
 
 private

--- a/app/models/scrape.rb
+++ b/app/models/scrape.rb
@@ -3,12 +3,24 @@ class Scrape < ApplicationRecord
       not_started: "not_started", completed: "completed", errored: "error"
     }, _prefix: true
 
+  before_validation :set_type
   before_create :ensure_callback_url
+
+  # We can't do this in Postgres so we verify it here
+  validates :scrape_type, presence: true
 
 private
 
   def ensure_callback_url
     self.callback_url = Figaro.env.ZENODOTUS_URL if self.callback_url.nil?
     raise "No callback url specific in configuration or passed in request" if self.callback_url.blank?
+  end
+
+  def set_type
+    return unless self.scrape_type.nil?
+
+    model = MediaSource.model_for_url(self.url)
+    raise MediaSource::HostError.new(self.url) if model.nil?
+    self.scrape_type = model.model_type
   end
 end

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -2,16 +2,11 @@
 # system we're deploying. The options (as of now) are as follows:
 # `instagram`
 # `facebook`
-Figaro.require_keys("DIFFERENTIATE_AS", "secret_key_base")
+Figaro.require_keys("secret_key_base")
 
-case Figaro.env.DIFFERENTIATE_AS
-when "instagram"
-  Figaro.require_keys("INSTAGRAM_USER_NAME", "INSTAGRAM_PASSWORD")
-when "facebook"
-  Figaro.require_keys("FACEBOOK_USER_NAME", "FACEBOOK_PASSWORD")
-else
-  raise "Invalid Differentiation Type: \"#{Figaro.env.DIFFERENTIATE_AS}\" must be of a valid type. Look at `/config/initializers/figaro.rb` for options."
-end
+
+Figaro.require_keys("INSTAGRAM_USER_NAME", "INSTAGRAM_PASSWORD")
+Figaro.require_keys("FACEBOOK_EMAIL", "FACEBOOK_PASSWORD")
 
 # We default to requiring ZENODOTUS_URL as a callback unless we explicitly set it otherwise.
 # Note: ZENODOTUS_URL can still be set, which will become the fallback if there's not a callback url passed in

--- a/db/migrate/20220218224600_remove_default_type_of_scrape.rb
+++ b/db/migrate/20220218224600_remove_default_type_of_scrape.rb
@@ -1,0 +1,9 @@
+class RemoveDefaultTypeOfScrape < ActiveRecord::Migration[7.0]
+  def up
+    change_column :scrapes, :scrape_type, :string, null: true, default: nil
+  end
+
+  def down
+    change_column :scrapes, :scrape_type, :string, null: false, default: ENV["DIFFERENTIATE_AS"]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_02_214234) do
+ActiveRecord::Schema.define(version: 2022_02_18_224600) do
 
   create_table "scrapes", force: :cascade do |t|
     t.string "url", null: false
     t.string "callback_url", null: false
     t.string "callback_id"
     t.string "status", default: "not_started", null: false
-    t.string "scrape_type", default: "instagram", null: false
+    t.string "scrape_type"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/test/media_sources/facebook_media_source_test.rb
+++ b/test/media_sources/facebook_media_source_test.rb
@@ -10,7 +10,7 @@ class FacebookMediaSourceTest < ActiveSupport::TestCase
   end
 
   test "can send error is there is an error while scraping" do
-    assert_raise(FacebookMediaSource::InvalidFacebookPostUrlError) do
+    assert_raise(MediaSource::HostError) do
       FacebookMediaSource.extract(Scrape.create({ url: "https://www.example.com" }))
     end
   end


### PR DESCRIPTION
This now supports running a scrape on any url passed in that is
supported. There's no more differentiation.

To test:
1. Remove `DIFFERENTIATE_AS` from `config/application.yml`
2. `rails db:migrate`
3. `rails t`