### PR TITLE
move attributes to downstream blueprints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     oj (3.13.11)
@@ -311,6 +313,8 @@ GEM
     strscan (3.0.1)
     tailwindcss-rails (2.0.7-arm64-darwin)
       railties (>= 6.0.0)
+    tailwindcss-rails (2.0.7-x86_64-darwin)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.0.7-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -350,6 +354,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/cguess/zorki
-  revision: 5d4578a18d512baf8b990a9391e89aeaa08217cb
+  revision: 11ea14ce367d56ca7cdaa489068004f345f5542d
   specs:
     zorki (0.1.0)
       apparition

--- a/app/blueprints/facebook_user_blueprint.rb
+++ b/app/blueprints/facebook_user_blueprint.rb
@@ -1,5 +1,5 @@
 class FacebookUserBlueprint < Blueprinter::Base
-  identifier :profile_link
+  identifier :id
 
   fields  :profile_link,
           :name,

--- a/app/blueprints/instagram_user_blueprint.rb
+++ b/app/blueprints/instagram_user_blueprint.rb
@@ -2,6 +2,7 @@ class InstagramUserBlueprint < Blueprinter::Base
   identifier :username
 
   fields  :name,
+          :username,
           :number_of_posts,
           :number_of_followers,
           :number_of_following,

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -1,21 +1,19 @@
 class UserBlueprint < Blueprinter::Base
-  identifier :username
+  identifier :name
+  fields :name
 
-  fields  :name,
-          :number_of_posts,
-          :number_of_followers,
-          :number_of_following,
-          :verified,
-          :profile,
-          :profile_link,
-          :profile_image,
-          :profile_image_url
-
-  field :profile_image do |user|
+  field :user do |user|
     to_return = nil
-    unless user.profile_image.nil?
-      file = File.open(user.profile_image).read
-      to_return = Base64.encode64(file)
+
+    case user.class.to_s # This is converted to a string because apparently comparing classes breaks
+    when "Forki::User"
+      byebug
+      to_return = FacebookUserBlueprint.render_as_hash(user)
+    when "Zorki::User"
+      byebug
+      to_return = InstagramUserBlueprint.render_as_hash(user)
+    else
+      raise "Unsupported class for a user passed into UseBlueprint"
     end
 
     to_return


### PR DESCRIPTION
This PR ensures that posts include a `Zorki/Forki::User`. It also deletes some superfluous fields from the base user blueprint. 