### PR TITLE
Prefix Active Job queues with Hypatia namespace

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,6 +65,9 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  # Prefix job queues names to avoid collisions
+  config.active_job.queue_name_prefix = "hypatia_development"
+
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
   config.hosts << "showoff-reporterslab.pagekite.me"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "hypatia_production"
+  config.active_job.queue_name_prefix = "hypatia_production"
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Prefix job queues names to avoid collisions
+  config.active_job.queue_name_prefix = "hypatia_test"
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,14 @@
 # We only want Sidekiq to do one at a time because of the way Selenium doesn't handle multithreading
 :concurrency: 1
+development:
+  :queues:
+    - [hypatia_development_urgent, 2]
+    - hypatia_development_default
+test:
+  :queues:
+    - [hypatia_test_urgent, 2]
+    - hypatia_test_default
+production:
+  :queues:
+    - [hypatia_production_urgent, 2]
+    - hypatia_production_default


### PR DESCRIPTION
This PR prefixes Active Job queue names with `hypatia_{environment}` to avoid queue collisions when Hypatia is being run on the same machine as another Sidekiq-using app (like Zenodotus locally).

To test:
- [ ] Clean `rails test` (except the existing test failure on `master`)
- [ ] Run the app and make sure archiving URLs still works
- [ ] Bonus points for doing the above while also running Zenodotus

🚨 Pay particular attention to the fact that I enabled prefixes in production, too. You may not want this! But I figured, hey, why not.

Closes #20