### PR TITLE
Equalize force nonforce

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/oneroyalace/forki
-  revision: b91018c20ee4df4149a4fc31773fcc65f2efc464
+  revision: fa73b94e2c6e7cfc33ada207ac175978a05b0ad1
   specs:
     forki (0.1.0)
       apparition
@@ -176,15 +176,15 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.3-arm64-darwin)
+    nokogiri (1.13.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-darwin)
+    nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     oj (3.13.11)
     parallel (1.22.1)
-    parser (3.1.1.0)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -192,7 +192,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -249,9 +249,9 @@ GEM
       rubocop-ast (>= 1.16.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.16.0)
+    rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
-    rubocop-minitest (0.19.0)
+    rubocop-minitest (0.19.1)
       rubocop (>= 0.90, < 2.0)
     rubocop-packaging (0.5.1)
       rubocop (>= 0.89, < 2.0)
@@ -262,7 +262,7 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
-    rubocop-rails_config (1.9.1)
+    rubocop-rails_config (1.9.2)
       railties (>= 5.0)
       rubocop (>= 1.25.1)
       rubocop-ast (>= 1.0.1)

--- a/app/controllers/scraper_controller.rb
+++ b/app/controllers/scraper_controller.rb
@@ -28,7 +28,8 @@ class ScraperController < ApplicationController
     end
 
     if params["force"] == "true" && Figaro.env.ALLOW_FORCE == "true"
-      render json: PostBlueprint.render(results) and return
+      params = { scrape_id: callback_id, scrape_result: PostBlueprint.render(results) }
+      render json: params.to_json and return
     end
 
     render json: { success: true }

--- a/app/jobs/scrape_job.rb
+++ b/app/jobs/scrape_job.rb
@@ -13,7 +13,6 @@ class ScrapeJob < ApplicationJob
 
     print "\n********************\n"
     print "Sending callback to #{callback_url}\n"
-    print "params: #{params.keys}"
     print "\n********************\n"
 
     Typhoeus.post("#{callback_url}/archive/scrape_result_callback",

--- a/test/controllers/scraper_controller_test.rb
+++ b/test/controllers/scraper_controller_test.rb
@@ -103,21 +103,21 @@ class ScraperControllerTest < ActionDispatch::IntegrationTest
   test "scraping an instagram image with force works" do
     get "/scrape.json", headers: { "Content-type" => "application/json" }, params: { url: "https://www.instagram.com/p/CS7npabI8IN/?utm_source=ig_web_copy_link", auth_key: @auth_key, force: "true" }
     assert_response 200
-    assert JSON.parse(@response.body).first.has_key?("id")
+    assert JSON.parse(JSON.parse(@response.body)["scrape_result"]).first.has_key?("id")
   end
 
   test "scraping an instagram video with force works" do
     assert_enqueued_jobs(0) do
       get "/scrape.json", headers: { "Content-type" => "application/json" }, params: { url: "https://www.instagram.com/p/CS17kK3n5-J/", auth_key: @auth_key, as: :json, force: "true" }
       assert_response 200
-      assert JSON.parse(@response.body).first.has_key?("id")
+      assert JSON.parse(JSON.parse(@response.body)["scrape_result"]).first.has_key?("id")
     end
   end
 
   test "scraping a facebook image with force works" do
     get "/scrape.json", headers: { "Content-type" => "application/json" }, params: { url: "https://www.facebook.com/photo/?fbid=10161587852468065&set=a.10150148489178065", auth_key: @auth_key, force: "true" }
     assert_response 200
-    parsed = JSON.parse(@response.body).first
+    parsed = JSON.parse(JSON.parse(@response.body)["scrape_result"]).first
 
     assert parsed.has_key?("id")
     assert parsed.has_key?("post")
@@ -129,7 +129,7 @@ class ScraperControllerTest < ActionDispatch::IntegrationTest
     assert_enqueued_jobs(0) do
       get "/scrape.json", headers: { "Content-type" => "application/json" }, params: { url: "https://www.facebook.com/PlandemicMovie/videos/588866298398729/", auth_key: @auth_key, as: :json, force: "true" }
       assert_response 200
-      assert JSON.parse(@response.body).first.has_key?("id")
+      assert JSON.parse(JSON.parse(@response.body)["scrape_result"]).first.has_key?("id")
     end
   end
 
@@ -148,7 +148,7 @@ class ScraperControllerTest < ActionDispatch::IntegrationTest
     assert_enqueued_jobs(0) do
       get "/scrape.json", headers: { "Content-type" => "application/json" }, params: { url: "https://www.instagram.com/p/CS17kK3n5-J/", auth_key: @auth_key, as: :json, force: "true" }
       assert_response 200
-      assert JSON.parse(@response.body).first.has_key?("id")
+      assert JSON.parse(JSON.parse(@response.body)["scrape_result"]).first.has_key?("id")
     end
   end
 end


### PR DESCRIPTION
This PR equalizes the response structure if a scrape is forced, or allowed to run async. This is necessary because I screwed up and wrote the tests to just expect one style whether it's forced or another one when it's not. That breaks... well, all common sense and is a classic mistake of TDD, whoops.

To test:
- `bundle update`
- `rails t`
- Then run the same in Zenodotus using the equivalent pr there.