### PR TITLE
Update YouTube test in line with Hypatia force changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,11 @@
 GIT
-  remote: https://github.com/cguess/zorki
-  revision: 11ea14ce367d56ca7cdaa489068004f345f5542d
+  remote: https://github.com/TechAndCheck/YoutubeArchiver
+  revision: 3b770fc612f79824898173daf76efd86711ac9ea
   specs:
-    zorki (0.1.0)
-      apparition
-      capybara
-      oj
-      selenium-webdriver
-      typhoeus
+    youtubearchiver (0.1.0)
 
 GIT
-  remote: https://github.com/oneroyalace/forki
+  remote: https://github.com/TechAndCheck/forki
   revision: fa73b94e2c6e7cfc33ada207ac175978a05b0ad1
   specs:
     forki (0.1.0)
@@ -20,10 +15,16 @@ GIT
       selenium-webdriver
       typhoeus
 
-PATH
-  remote: ../YoutubeArchiver
+GIT
+  remote: https://github.com/cguess/zorki
+  revision: 11ea14ce367d56ca7cdaa489068004f345f5542d
   specs:
-    youtubearchiver (0.1.0)
+    zorki (0.1.0)
+      apparition
+      capybara
+      oj
+      selenium-webdriver
+      typhoeus
 
 GEM
   remote: https://rubygems.org/
@@ -297,7 +298,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
     set (1.0.2)
-    sidekiq (6.4.1)
+    sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)

--- a/test/controllers/scraper_controller_test.rb
+++ b/test/controllers/scraper_controller_test.rb
@@ -138,7 +138,7 @@ class ScraperControllerTest < ActionDispatch::IntegrationTest
     assert_enqueued_jobs(0) do
       get "/scrape.json", headers: { "Content-type" => "application/json" }, params: { url: "https://www.youtube.com/watch?v=MUaNz9M8fs8", auth_key: @auth_key, as: :json, force: "true" }
       assert_response 200
-      assert JSON.parse(@response.body).first.has_key?("id")
+      assert JSON.parse(JSON.parse(@response.body)["scrape_result"]).first.has_key?("id")
     end
   end
 


### PR DESCRIPTION
This PR updates the scraper_controller test for YouTube per the changes in https://github.com/TechAndCheck/hypatia/pull/23

# Testing
- `bundle install`
- `rail t`