### PR TITLE
Update Zorki with new scraping paradigm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ yarn-debug.log*
 /.nova
 
 dump.rdb
+
+selenium-server-*
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/cguess/zorki
-  revision: 4e22d266d2cf6c6998ff75b4803591ddbc0a3d13
+  revision: 1a3831f78717415e6d0b7ea82e55bd31577fdb0d
   specs:
     zorki (0.1.0)
       apparition

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,12 +17,13 @@ GIT
 
 GIT
   remote: https://github.com/cguess/zorki
-  revision: ed52f5cce436285a5f827e25bc5ce1f8dd8e0858
+  revision: 77034f5a92ee1ed97c3e402c677bf43bf61f3ac6
   specs:
     zorki (0.1.0)
       apparition
       capybara
       oj
+      selenium-devtools
       selenium-webdriver
       typhoeus
 
@@ -189,7 +190,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
-    oj (3.13.13)
+    oj (3.13.14)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -203,7 +204,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-mini-profiler (2.3.4)
       rack (>= 1.2.0)
     rack-test (1.1.0)
@@ -243,7 +244,7 @@ GEM
       ffi (~> 1.0)
     rbtree (0.4.5)
     redis (4.6.0)
-    regexp_parser (2.4.0)
+    regexp_parser (2.5.0)
     reline (0.3.1)
       io-console (~> 0.5)
     rexml (3.2.5)
@@ -293,10 +294,13 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.1.0)
+    selenium-devtools (0.102.0)
+      websocket (~> 1.0)
+    selenium-webdriver (4.2.1)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     set (1.0.2)
     sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
@@ -348,6 +352,7 @@ GEM
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
     webrick (1.7.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/cguess/zorki
-  revision: 1a3831f78717415e6d0b7ea82e55bd31577fdb0d
+  revision: 089fe2713f8e7b5fe8fca9b78d6551056b1a3fbc
   specs:
     zorki (0.1.0)
       apparition

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/cguess/zorki
-  revision: 77034f5a92ee1ed97c3e402c677bf43bf61f3ac6
+  revision: 4e22d266d2cf6c6998ff75b4803591ddbc0a3d13
   specs:
     zorki (0.1.0)
       apparition

--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@ The scrapers are kept separate from Zenodotus, because the IP addresses of tradi
 1. Create `config/application.yml` and create `INSTAGRAM_USER_NAME`, `INSTAGRAM_PASSWORD`.
 1. Run `$ rails secret` and then add a variable `secret_key_base` to `config/application.yml`
 1. `$ rails db:migrate` to setup the database (this uses SQLite so there's no need for Postgres or MySQL or anything)
+1. Setup Selenium standalone server
+	1. Download the "Selenium Server (Grid)" JAR package at https://www.selenium.dev/downloads/
+	1. Save it to the folder of this package
+	1. Test that it works by running `java -jar ./selenium-server-4.2.1.jar standalone` (note the actual version you downloaded)
 1. Generate an API key for security purposes in the Rails console
 	1. `$ rails c`
 	1. `Setting.generate_auth_key`
 	1. Note this key in a password manager or something, you'll need it later. It's currently stored in the database (this should be hashed at some point, but meh for now)
 	1. `exit`
+1. Start up the Selenium server `java -jar ./selenium-server-4.2.1.jar standalone` in a separate CLI pane
 1. Start up the server `$ rails s`
 
 If your auth key gets compromised just reload it using the same steps above.

--- a/app/media_sources/instagram_media_source.rb
+++ b/app/media_sources/instagram_media_source.rb
@@ -51,7 +51,16 @@ class InstagramMediaSource < MediaSource
   # @return [Zorki::Post]
   def retrieve_instagram_post
     id = InstagramMediaSource.extract_instagram_id_from_url(@url)
-    Zorki::Post.lookup(id)
+
+    # Zorki is a little flaky now, so this is a retry
+    retry_count = 0
+
+    begin
+      Zorki::Post.lookup(id)
+    rescue Selenium::WebDriver::Error::WebDriverError => e
+      retry_count += 1
+      raise e if retry_count > 5
+    end
   end
 
   def self.can_handle_url?(url)


### PR DESCRIPTION
OOOH BOY! This is a big one. Instagram removed the graphql object from
being sent along with the initial page load and instead does it on
a subsequent sub page load. Well, that's an issue since we have to
actually have to look out for these and intercept them, which this does.

This is a bit flakier, but overall works well and all tests pass. So to
manage that it also adds a retry system

This also fixes an issue with relogging in a lot even if you're already
logged in.

To test:
1. `bundle install`
1. Review the new added parts of the README and follow the instructions. 
1. Start up the Selenium server `java -jar ./selenium-server-4.2.1.jar standalone`
1. `rails test`