### PR TITLE
Speed up tests

### DIFF
--- a/test/media_sources/facebook_media_source_test.rb
+++ b/test/media_sources/facebook_media_source_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class FacebookMediaSourceTest < ActiveSupport::TestCase
   def setup; end
-  @@facebook_image_post_array = FacebookMediaSource.extract(Scrape.create({ url: "https://www.facebook.com/photo/?fbid=10161587852468065&set=a.10150148489178065" }))
-  @@facebook_video_post_array = FacebookMediaSource.extract(Scrape.create({ url: "https://www.facebook.com/Meta/videos/264436895517475" }))
+  @@facebook_image_posts = FacebookMediaSource.extract(Scrape.create({ url: "https://www.facebook.com/photo/?fbid=10161587852468065&set=a.10150148489178065" }))
+  @@facebook_video_posts = FacebookMediaSource.extract(Scrape.create({ url: "https://www.facebook.com/Meta/videos/264436895517475" }))
 
   test "can send error via slack notification" do
     assert_nothing_raised do
@@ -25,18 +25,18 @@ class FacebookMediaSourceTest < ActiveSupport::TestCase
   end
 
   test "extracted video has screenshot" do
-    assert_not_nil @@facebook_video_post_array.first.screenshot_file
+    assert_not_nil @@facebook_video_posts.first.screenshot_file
   end
 
   test "extracted post has images and videos uploaded to S3" do
     skip unless ENV["AWS_REGION"].present?
 
-    posts = @@facebook_image_post_array
+    posts = @@facebook_image_posts
     assert_not_nil(posts)
 
     posts.each { |post| assert_not_nil(post.aws_image_keys) }
 
-    posts = @@facebook_video_post_array
+    posts = @@facebook_video_posts
     assert_not_nil(posts)
 
     posts.each { |post| assert_not_nil(post.aws_video_key) }

--- a/test/media_sources/youtube_media_source_test.rb
+++ b/test/media_sources/youtube_media_source_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class YoutubeMediaSourceTest < ActiveSupport::TestCase
   def setup; end
 
+  @@youtube_posts = YoutubeMediaSource.extract(Scrape.create({ url: "https://www.youtube.com/watch?v=Df7UtQTFUMQ" }))
+
   test "can send error via slack notification" do
     assert_nothing_raised do
       YoutubeMediaSource.send_message_to_slack("Test message for Youtube Media Source")
@@ -17,25 +19,22 @@ class YoutubeMediaSourceTest < ActiveSupport::TestCase
 
   test "can extract video without an error being posted to Slack" do
     assert_nothing_raised do
-      video = YoutubeMediaSource.extract(Scrape.create({ url: "https://www.youtube.com/watch?v=Df7UtQTFUMQ" })) # short video = quick test
-      assert_not_nil(video)
+      assert_not_nil(@@youtube_posts.first)
     end
   end
 
   test "extracted video has screenshot" do
-    posts = YoutubeMediaSource.extract(Scrape.create({ url: "https://www.youtube.com/watch?v=Df7UtQTFUMQ" }))
-    posts.each { |post| assert_not_nil(post.screenshot_file) }
+    @@youtube_posts.each { |post| assert_not_nil(post.screenshot_file) }
   end
 
   test "extracted video uploaded to S3" do
     skip unless ENV["AWS_REGION"].present?
 
-    posts = YoutubeMediaSource.extract(Scrape.create({ url: "https://www.youtube.com/watch?v=Df7UtQTFUMQ" }))
-    assert_not_nil(posts)
+    assert_not_nil(@@youtube_posts)
 
-    posts.each { |post| assert_not_nil(post.aws_video_key) }
-    posts.each { |post| assert_not_nil(post.aws_video_preview_key) }
-    posts.each { |post| assert_not_nil(post.aws_screenshot_key) }
+    @@youtube_posts.each { |post| assert_not_nil(post.aws_video_key) }
+    @@youtube_posts.each { |post| assert_not_nil(post.aws_video_preview_key) }
+    @@youtube_posts.each { |post| assert_not_nil(post.aws_screenshot_key) }
   end
 
   test "extracted video is not uploaded to S3 if AWS_REGION isn't set" do
@@ -52,14 +51,13 @@ class YoutubeMediaSourceTest < ActiveSupport::TestCase
   test "extracted video uploaded to S3 does not have Base64 in JSON version" do
     skip unless ENV["AWS_REGION"].present?
 
-    posts = YoutubeMediaSource.extract(Scrape.create({ url: "https://www.youtube.com/watch?v=Df7UtQTFUMQ" }))
-    assert_not_nil(posts)
+    assert_not_nil(@@youtube_posts)
 
-    posts.each { |post| assert_not_nil(post.aws_video_key) }
-    posts.each { |post| assert_not_nil(post.aws_video_preview_key) }
-    posts.each { |post| assert_not_nil(post.aws_screenshot_key) }
+    @@youtube_posts.each { |post| assert_not_nil(post.aws_video_key) }
+    @@youtube_posts.each { |post| assert_not_nil(post.aws_video_preview_key) }
+    @@youtube_posts.each { |post| assert_not_nil(post.aws_screenshot_key) }
 
-    json_posts = JSON.parse(PostBlueprint.render(posts))
+    json_posts = JSON.parse(PostBlueprint.render(@@youtube_posts))
     json_posts.each { |post| assert_nil post["post"]["image_files"] }
     json_posts.each { |post| assert_nil post["post"]["video_file"] }
     json_posts.each { |post| assert_nil post["post"]["video_file_preview"] }


### PR DESCRIPTION
This PR changes the Hypatia media source tests so that they re-use scraped media when possible. The PR reduces test suite duration by ~30%, from ~1000s to ~700s. 

Closes #47 

# Testing instructions
`rails t`

# Merge instructions
This branch is based off of https://github.com/TechAndCheck/hypatia/pull/46 and should either be merged into it or be merged to `master` after it. 