### PR TITLE
Send profile images via s3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/TechAndCheck/YoutubeArchiver
-  revision: 7b07d571c38600ee29d46533d38a70e85eb59d5c
+  revision: 0683be2cc0f7c4ce47db20eac8d315097b958df3
   specs:
     youtubearchiver (0.1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-devtools (0.104.0)
+    selenium-devtools (0.105.0)
       selenium-webdriver (~> 4.2)
     selenium-webdriver (4.4.0)
       childprocess (>= 0.5, < 5.0)

--- a/app/blueprints/facebook_user_blueprint.rb
+++ b/app/blueprints/facebook_user_blueprint.rb
@@ -9,12 +9,16 @@ class FacebookUserBlueprint < Blueprinter::Base
           :number_of_likes,
           :verified,
           :profile_image_file,
-          :profile_image_url
+          :profile_image_url,
+          :aws_profile_image_key
 
   field :profile_image_file do |user|
-    unless user.profile_image_file.nil?
+    to_return = nil
+    if user.profile_image_file.nil? == false && user.aws_profile_image_key.blank?
       file = File.open(user.profile_image_file).read
-      Base64.encode64(file)
+      to_return = Base64.encode64(file)
     end
+
+    to_return
   end
 end

--- a/app/blueprints/instagram_user_blueprint.rb
+++ b/app/blueprints/instagram_user_blueprint.rb
@@ -10,11 +10,12 @@ class InstagramUserBlueprint < Blueprinter::Base
           :profile,
           :profile_link,
           :profile_image,
-          :profile_image_url
+          :profile_image_url,
+          :aws_profile_image_key
 
   field :profile_image do |user|
     to_return = nil
-    unless user.profile_image.nil?
+    if user.profile_image.nil? == false && user.aws_profile_image_key.blank?
       file = File.open(user.profile_image).read
       to_return = Base64.encode64(file)
     end

--- a/app/blueprints/youtube_channel_blueprint.rb
+++ b/app/blueprints/youtube_channel_blueprint.rb
@@ -9,12 +9,16 @@ class YoutubeChannelBlueprint < Blueprinter::Base
           :view_count,
           :description,
           :made_for_kids,
-          :channel_image_file
+          :channel_image_file,
+          :aws_profile_image_key
 
   field :channel_image_file do |channel|
-    unless channel.channel_image_file.nil?
+    to_return = nil
+    if channel.channel_image_file.nil? == false && channel.aws_profile_image_key.blank?
       file = File.open(channel.channel_image_file).read
-      Base64.encode64(file)
+      to_return = Base64.encode64(file)
     end
+
+    to_return
   end
 end

--- a/app/blueprints/youtube_video_blueprint.rb
+++ b/app/blueprints/youtube_video_blueprint.rb
@@ -13,13 +13,6 @@ class YoutubeVideoBlueprint < Blueprinter::Base
 
   association :channel, blueprint: YoutubeChannelBlueprint
 
-  field :video_preview_image_file do |video|
-    unless video.video_preview_image_file.nil?
-      file = File.open(video.video_preview_image_file).read
-      Base64.encode64(file)
-    end
-  end
-
   field :video_file do |video|
     if video.video_file.nil? == false && video.aws_video_key.blank?
       file = File.open(video.video_file).read
@@ -52,7 +45,7 @@ class YoutubeVideoBlueprint < Blueprinter::Base
     video.aws_video_preview_key()
   end
 
-  field :aws_video_preview_key do |video|
+  field :aws_screenshot_key do |video|
     video.aws_screenshot_key()
   end
 end

--- a/app/media_sources/facebook_media_source.rb
+++ b/app/media_sources/facebook_media_source.rb
@@ -70,6 +70,14 @@ class FacebookMediaSource < MediaSource
     posts.map do |post|
       @@logger.debug "Beginning uploading of files to S3 bucket #{Figaro.env.AWS_S3_BUCKET_NAME}"
 
+      # Upload user profile picture to s3
+      if post.user.profile_image_file.present?
+        @@logger.debug "Uploading user profile picture #{post.user.profile_image_file}"
+        aws_upload_wrapper = AwsObjectUploadFileWrapper.new(post.user.profile_image_file)
+        aws_upload_wrapper.upload_file
+        post.user.instance_variable_set("@aws_profile_image_key", aws_upload_wrapper.object.key)
+      end
+
       # Upload post screenshot to s3
       if post.screenshot_file.present?
         @@logger.debug "Uploading post screenshot #{post.screenshot_file}"

--- a/app/media_sources/instagram_media_source.rb
+++ b/app/media_sources/instagram_media_source.rb
@@ -59,6 +59,14 @@ class InstagramMediaSource < MediaSource
     posts.map do |post|
       @@logger.debug "Beginning uploading of files to S3 bucket #{Figaro.env.AWS_S3_BUCKET_NAME}"
 
+      # Upload user profile picture to s3
+      if post.user.profile_image.present?
+        @@logger.debug "Uploading user profile picture #{post.user.profile_image}"
+        aws_upload_wrapper = AwsObjectUploadFileWrapper.new(post.user.profile_image)
+        aws_upload_wrapper.upload_file
+        post.user.instance_variable_set("@aws_profile_image_key", aws_upload_wrapper.object.key)
+      end
+
       # Upload post screenshot to s3
       if post.screenshot_file.present?
         @@logger.debug "Uploading post screenshot #{post.screenshot_file}"

--- a/app/media_sources/media_source.rb
+++ b/app/media_sources/media_source.rb
@@ -62,7 +62,7 @@ class MediaSource
   end
 
   def self.create_aws_key_functions_for_posts(posts)
-    posts.map do |post|
+    posts.each do |post|
       # First, we add two functions to whatever class the result is.
       # These are implementation details, so we don't want to add them to Zorki or Forki
       # These will allow us to save the AWS keys for later
@@ -87,7 +87,22 @@ class MediaSource
         instance_variable_get("@aws_screenshot_key")
       end
 
+      self.create_aws_key_functions_for_users(post.user)
+
       post
+    end
+  end
+
+  # Add AWS key instance variable getters to a User object
+  # Modifies the initial object.
+  #
+  # @param url A user objects constructed by one of the scraper gems
+  # @return nil
+  def self.create_aws_key_functions_for_users(user)
+    user.instance_variable_set("@aws_profile_image_key", nil)
+
+    user.define_singleton_method(:aws_profile_image_key) do
+      instance_variable_get("@aws_profile_image_key")
     end
   end
 

--- a/app/media_sources/youtube_media_source.rb
+++ b/app/media_sources/youtube_media_source.rb
@@ -86,6 +86,14 @@ class YoutubeMediaSource < MediaSource
     posts.map do |post|
       @@logger.debug "Beginning uploading of files to S3 bucket #{Figaro.env.AWS_S3_BUCKET_NAME}"
 
+      # Upload channel profile picture to s3
+      if post.channel.channel_image_file.present?
+        @@logger.debug "Uploading channel image #{post.channel.channel_image_file}"
+        aws_upload_wrapper = AwsObjectUploadFileWrapper.new(post.channel.channel_image_file)
+        aws_upload_wrapper.upload_file
+        post.channel.instance_variable_set("@aws_profile_image_key", aws_upload_wrapper.object.key)
+      end
+
       if post.screenshot_file.present?
         @@logger.debug "Uploading post screenshot #{post.screenshot_file}"
         aws_upload_wrapper = AwsObjectUploadFileWrapper.new(post.screenshot_file)

--- a/test/media_sources/facebook_media_source_test.rb
+++ b/test/media_sources/facebook_media_source_test.rb
@@ -49,7 +49,7 @@ class FacebookMediaSourceTest < ActiveSupport::TestCase
     json_posts.each { |post| assert_nil post["post"]["video_file"] }
     json_posts.each { |post| assert_nil post["post"]["video_file_preview"] }
     json_posts.each { |post| assert_nil post["post"]["screenshot_file"] }
-    json_posts.each { |post| assert_nil post["post"]["user"]["aws_profile_image_key"] }
+    json_posts.each { |post| assert_not_nil post["post"]["user"]["aws_profile_image_key"] }
   end
 
   test "extracted post has images and videos are not uploaded to S3 if AWS_REGION isn't set" do

--- a/test/media_sources/facebook_media_source_test.rb
+++ b/test/media_sources/facebook_media_source_test.rb
@@ -42,12 +42,14 @@ class FacebookMediaSourceTest < ActiveSupport::TestCase
     posts.each { |post| assert_not_nil(post.aws_video_key) }
     posts.each { |post| assert_not_nil(post.aws_video_preview_key) }
     posts.each { |post| assert_not_nil(post.aws_screenshot_key) }
+    posts.each { |post| assert_not_nil(post.user.aws_profile_image_key) }
 
     json_posts = JSON.parse(PostBlueprint.render(posts))
     json_posts.each { |post| assert_nil post["post"]["image_files"] }
     json_posts.each { |post| assert_nil post["post"]["video_file"] }
     json_posts.each { |post| assert_nil post["post"]["video_file_preview"] }
     json_posts.each { |post| assert_nil post["post"]["screenshot_file"] }
+    json_posts.each { |post| assert_nil post["post"]["user"]["aws_profile_image_key"] }
   end
 
   test "extracted post has images and videos are not uploaded to S3 if AWS_REGION isn't set" do
@@ -59,6 +61,7 @@ class FacebookMediaSourceTest < ActiveSupport::TestCase
       posts.each { |post| assert_nil(post.aws_video_key) }
       posts.each { |post| assert_nil(post.aws_video_preview_key) }
       posts.each { |post| assert_nil(post.aws_screenshot_key) }
+      posts.each { |post| assert_nil(post.user.aws_profile_image_key) }
 
       posts = FacebookMediaSource.extract(Scrape.create({ url: "https://www.facebook.com/Meta/videos/264436895517475" }))
       assert_not_nil(posts)
@@ -67,12 +70,14 @@ class FacebookMediaSourceTest < ActiveSupport::TestCase
       posts.each { |post| assert_nil(post.aws_video_key) }
       posts.each { |post| assert_nil(post.aws_video_preview_key) }
       posts.each { |post| assert_nil(post.aws_screenshot_key) }
+      posts.each { |post| assert_nil(post.user.aws_profile_image_key) }
 
       json_posts = JSON.parse(PostBlueprint.render(posts))
       json_posts.each { |post| assert_nil post["post"]["aws_image_keys"] }
       json_posts.each { |post| assert_nil post["post"]["aws_video_key"] }
       json_posts.each { |post| assert_nil post["post"]["aws_video_preview_key"] }
       json_posts.each { |post| assert_nil post["post"]["aws_screenshot_key"] }
+      json_posts.each { |post| assert_nil post["post"]["user"]["aws_profile_image_key"] }
     end
   end
 end

--- a/test/media_sources/instagram_media_source_test.rb
+++ b/test/media_sources/instagram_media_source_test.rb
@@ -44,12 +44,14 @@ class InstagramMediaSourceTest < ActiveSupport::TestCase
     @@instagram_video_posts.each { |post| assert_not_nil(post.aws_video_key) }
     @@instagram_video_posts.each { |post| assert_not_nil(post.aws_video_preview_key) }
     @@instagram_video_posts.each { |post| assert_not_nil(post.aws_screenshot_key) }
+    @@instagram_video_posts.each { |post| assert_not_nil(post.user.aws_profile_image_key) }
 
     json_posts = JSON.parse(PostBlueprint.render(@@instagram_video_posts))
     json_posts.each { |post| assert_nil post["post"]["image_files"] }
     json_posts.each { |post| assert_nil post["post"]["video_file"] }
     json_posts.each { |post| assert_nil post["post"]["video_file_preview"] }
     json_posts.each { |post| assert_nil post["post"]["screenshot_file"] }
+    json_posts.each { |post| assert_nil post["post"]["user"]["aws_profile_image_key"] }
   end
 
   test "extracted post has images and videos are not uploaded to S3 if AWS_REGION isn't set" do
@@ -66,12 +68,14 @@ class InstagramMediaSourceTest < ActiveSupport::TestCase
       posts.each { |post| assert_nil(post.aws_video_key) }
       posts.each { |post| assert_nil(post.aws_video_preview_key) }
       posts.each { |post| assert_nil(post.aws_screenshot_key) }
+      posts.each { |post| assert_nil(post.user.aws_profile_image_key) }
 
       json_posts = JSON.parse(PostBlueprint.render(posts))
       json_posts.each { |post| assert_nil post["post"]["aws_image_keys"] }
       json_posts.each { |post| assert_nil post["post"]["aws_video_key"] }
       json_posts.each { |post| assert_nil post["post"]["aws_video_preview_key"] }
       json_posts.each { |post| assert_nil post["post"]["aws_screenshot_key"] }
+      json_posts.each { |post| assert_nil post["post"]["user"]["aws_profile_image_key"] }
     end
   end
 end

--- a/test/media_sources/instagram_media_source_test.rb
+++ b/test/media_sources/instagram_media_source_test.rb
@@ -51,7 +51,7 @@ class InstagramMediaSourceTest < ActiveSupport::TestCase
     json_posts.each { |post| assert_nil post["post"]["video_file"] }
     json_posts.each { |post| assert_nil post["post"]["video_file_preview"] }
     json_posts.each { |post| assert_nil post["post"]["screenshot_file"] }
-    json_posts.each { |post| assert_nil post["post"]["user"]["aws_profile_image_key"] }
+    json_posts.each { |post| assert_not_nil post["post"]["user"]["aws_profile_image_key"] }
   end
 
   test "extracted post has images and videos are not uploaded to S3 if AWS_REGION isn't set" do

--- a/test/media_sources/youtube_media_source_test.rb
+++ b/test/media_sources/youtube_media_source_test.rb
@@ -35,6 +35,7 @@ class YoutubeMediaSourceTest < ActiveSupport::TestCase
     @@youtube_posts.each { |post| assert_not_nil(post.aws_video_key) }
     @@youtube_posts.each { |post| assert_not_nil(post.aws_video_preview_key) }
     @@youtube_posts.each { |post| assert_not_nil(post.aws_screenshot_key) }
+    @@youtube_posts.each { |post| assert_not_nil(post.user.aws_profile_image_key) }
   end
 
   test "extracted video is not uploaded to S3 if AWS_REGION isn't set" do
@@ -45,6 +46,7 @@ class YoutubeMediaSourceTest < ActiveSupport::TestCase
       posts.each { |post| assert_nil(post.aws_video_key) }
       posts.each { |post| assert_nil(post.aws_video_preview_key) }
       posts.each { |post| assert_nil(post.aws_screenshot_key) }
+      posts.each { |post| assert_nil(post.user.aws_profile_image_key) }
     end
   end
 
@@ -56,12 +58,14 @@ class YoutubeMediaSourceTest < ActiveSupport::TestCase
     @@youtube_posts.each { |post| assert_not_nil(post.aws_video_key) }
     @@youtube_posts.each { |post| assert_not_nil(post.aws_video_preview_key) }
     @@youtube_posts.each { |post| assert_not_nil(post.aws_screenshot_key) }
+    @@youtube_posts.each { |post| assert_not_nil(post.user.aws_profile_image_key) }
 
     json_posts = JSON.parse(PostBlueprint.render(@@youtube_posts))
     json_posts.each { |post| assert_nil post["post"]["image_files"] }
     json_posts.each { |post| assert_nil post["post"]["video_file"] }
     json_posts.each { |post| assert_nil post["post"]["video_file_preview"] }
     json_posts.each { |post| assert_nil post["post"]["screenshot_file"] }
+    json_posts.each { |post| assert_nil post["post"]["channel"]["profile_image_file"] }
   end
 
   test "extracted video is not uploaded to S3 if AWS_REGION isn't set and does have Base64 in JSON version" do
@@ -73,12 +77,14 @@ class YoutubeMediaSourceTest < ActiveSupport::TestCase
       posts.each { |post| assert_nil(post.aws_video_key) }
       posts.each { |post| assert_nil(post.aws_video_preview_key) }
       posts.each { |post| assert_nil(post.aws_screenshot_key) }
+      posts.each { |post| assert_nil(post.user.aws_profile_image_key) }
 
       json_posts = JSON.parse(PostBlueprint.render(posts))
       json_posts.each { |post| assert_nil post["post"]["aws_image_keys"] }
       json_posts.each { |post| assert_nil post["post"]["aws_video_key"] }
       json_posts.each { |post| assert_nil post["post"]["aws_video_preview_key"] }
       json_posts.each { |post| assert_nil post["post"]["aws_screenshot_key"] }
+      json_posts.each { |post| assert_nil post["post"]["channel"]["aws_profile_image_key"] }
     end
   end
 end


### PR DESCRIPTION
This PR changes our method of transferring profile images from HTTPS to s3, bringing it in line with our method of transferring other media. 

# Testing instructions
Makes sure https://github.com/TechAndCheck/YoutubeArchiver/pull/9 is merged (or check its branch out in your local Gemfile)
`rake test`