### PR TITLE
Bump sidekiq to fix error from redis

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,10 +331,10 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     set (1.0.2)
-    sidekiq (6.5.5)
-      connection_pool (>= 2.2.2)
+    sidekiq (6.5.6)
+      connection_pool (>= 2.2.5)
       rack (~> 2.0)
-      redis (>= 4.5.0)
+      redis (>= 4.5.0, < 5)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)


### PR DESCRIPTION
Redis was throwing a bunch of errors since we bumped to 4.8.0. This bumps Sidekiq as well to fix that up.