### PR TITLE
Update Birdsong

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem "zorki", "0.1.0", git: "https://github.com/cguess/zorki"
 gem "forki", "0.1.0", git: "https://github.com/TechAndCheck/forki"
 # gem "forki", "0.1.0", path: "/Users/christopher/Repositories/Reporters_Lab/forki"
 gem "youtubearchiver", git: "https://github.com/TechAndCheck/YoutubeArchiver"
-gem "birdsong", "0.1.0", git: "https://github.com/cguess/birdsong", branch: "archive-gifs"
+gem "birdsong", "0.1.0", git: "https://github.com/cguess/birdsong"
 
 # Run shell commands (yt-dlp)
 gem "terrapin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/cguess/birdsong
-  revision: 7a18ddf66efd1b957cda340ffefbf79dc1ce9d32
-  branch: archive-gifs
+  revision: 5a3c0ea58040517ef8d1289055a2a0f1bc418559
   specs:
     birdsong (0.1.0)
       oauth (~> 0.5.6)
@@ -218,7 +217,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
-    oauth (0.5.13)
+    oauth (0.5.14)
     oj (3.13.21)
     parallel (1.22.1)
     parser (3.1.2.1)

--- a/app/controllers/scraper_controller.rb
+++ b/app/controllers/scraper_controller.rb
@@ -18,7 +18,8 @@ class ScraperController < ApplicationController
     begin
       retry_count ||= 0
       results = MediaSource.scrape(url, callback_id, callback_url, force: force)
-    rescue MediaSource::HostError
+    rescue MediaSource::HostError => e
+      debugger
       render json: { error: "Url must be a proper #{ApplicationController.name_for_differentiated_type} url" }, status: 400
       return
     rescue Net::ReadTimeout => error

--- a/app/controllers/scraper_controller.rb
+++ b/app/controllers/scraper_controller.rb
@@ -19,8 +19,7 @@ class ScraperController < ApplicationController
       retry_count ||= 0
       results = MediaSource.scrape(url, callback_id, callback_url, force: force)
     rescue MediaSource::HostError => e
-      debugger
-      render json: { error: "Url must be a proper #{ApplicationController.name_for_differentiated_type} url" }, status: 400
+      render json: { error: e }, status: 400
       return
     rescue Net::ReadTimeout => error
       print({ error: "Net::ReadTimeout encountered while scraping", url: url, count: retry_count += 1 }.to_json)

--- a/app/media_sources/media_source.rb
+++ b/app/media_sources/media_source.rb
@@ -93,8 +93,6 @@ class MediaSource
         instance_variable_get("@aws_screenshot_key")
       end
 
-      self.create_aws_key_functions_for_users(post.user)
-
       post
     end
   end

--- a/app/media_sources/media_source.rb
+++ b/app/media_sources/media_source.rb
@@ -93,6 +93,8 @@ class MediaSource
         instance_variable_get("@aws_screenshot_key")
       end
 
+      self.create_aws_key_functions_for_users(post.user)
+
       post
     end
   end


### PR DESCRIPTION
This updates Birdsong gem to fix an issue with twitter posts using `author` instead of `user`

To test without running the tests:
- Start up a server
- Make sure you have the auth key generated
- Make a curl call such as:
```
curl --location --request GET 'http://localhost:3001/scrape.json?auth_key=kRAIXJCnavVreybCBCWQFBhylTraGP&url=https://twitter.com/AmtrakNECAlerts/status/1397922363551870990&force=true' \
--header 'Cookie: __profilin=p%3Dt'
```

From here it should just work