### PR TITLE
Add AWS upload for twitter profile images

### DIFF
--- a/app/blueprints/twitter_user_blueprint.rb
+++ b/app/blueprints/twitter_user_blueprint.rb
@@ -10,11 +10,12 @@ class TwitterUserBlueprint < Blueprinter::Base
           :profile_image_url,
           :location,
           :followers_count,
-          :following_count
+          :following_count,
+          :aws_profile_image_key
 
   field :profile_image do |user|
     to_return = nil
-    unless user.profile_image_file_name.nil?
+    if user.profile_image_file_name.nil? == false && user.aws_profile_image_key.blank?
       file = File.open(user.profile_image_file_name).read
       to_return = Base64.encode64(file)
     end

--- a/app/media_sources/twitter_media_source.rb
+++ b/app/media_sources/twitter_media_source.rb
@@ -64,6 +64,14 @@ class TwitterMediaSource < MediaSource
 
     return [tweet] unless s3_transfer_enabled?
 
+    # Upload user profile picture to s3
+    if tweet.author.profile_image_file_name.present?
+      @@logger.debug "Uploading user profile picture #{tweet.author.profile_image_file_name}"
+      aws_upload_wrapper = AwsObjectUploadFileWrapper.new(tweet.author.profile_image_file_name)
+      aws_upload_wrapper.upload_file
+      tweet.author.instance_variable_set("@aws_profile_image_key", aws_upload_wrapper.object.key)
+    end
+
     # Upload tweet screenshot to s3
     if tweet.screenshot_file.present?
       @@logger.debug "Uploading tweet screenshot #{tweet.screenshot_file}"

--- a/test/media_sources/twitter_media_source_test.rb
+++ b/test/media_sources/twitter_media_source_test.rb
@@ -52,6 +52,15 @@ class TwietterSourceTest < ActiveSupport::TestCase
     tweets.each { |tweet| assert_not_nil(tweet.aws_image_keys) }
   end
 
+  test "tweet author has profile image aws key" do
+    skip unless ENV["AWS_REGION"].present?
+
+    tweets = TwitterMediaSource.extract(Scrape.create({ url: "https://twitter.com/Space4Europe/status/1552221138037755904" }))
+    assert_not_nil(tweets.first.author.aws_profile_image_key)
+
+    tweets.each { |tweet| assert_not_nil(tweet.author.aws_profile_image_key) }
+  end
+
   test "extracted image is not uploaded to S3 if AWS_REGION isn't set" do
     modify_environment_variable("AWS_REGION", nil) do
       tweet = TwitterMediaSource.extract(Scrape.create({ url: "https://twitter.com/Space4Europe/status/1552221138037755904" }))


### PR DESCRIPTION
This adds the feature that's on all the other models to upload the Twitter User profile image to AWS.

`rails t` that's it for testing.